### PR TITLE
Fix typo in server class

### DIFF
--- a/tactigon_shapes/__init__.py
+++ b/tactigon_shapes/__init__.py
@@ -50,7 +50,7 @@ class Server(Process):
         while not self._ready_flag.is_set():
             time.sleep(0.5)
 
-        input("Type ant key to exit...\n")
+        input("Type any key to exit...\n")
     
         self.stop()
         self.terminate()


### PR DESCRIPTION
## Description:
This PR corrects a minor spelling error in the Server class in the init file.

- Before: "ant"
- After: "any"